### PR TITLE
Hotfix plotting 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 Tools for time-frequency analysis of noisy time series. More details can be found in the
 accompanying manuscript [Optimal time frequency analysis for biological data - pyBOAT](https://biorxiv.org/cgi/content/short/2020.04.29.067744v3). For help, questions or comments please join the official chat on [gitter](https://gitter.im/pyBOATbase/support), write [an issue](https://github.com/tensionhead/pyBOAT/issues) or [start a discussion](https://github.com/tensionhead/pyBOAT/discussions).
 
-pyBOAT features a multi-layered graphical user interface. Here an example screenshot showing the `DataViewer`(left), where preprocessing of individual signals gets visualized, and the resulting `Wavelet Spectrum` with a ridge tracing the detected  main oscillatory component with a  $\sim$ 24h period (right):
+[Installation](#installation)
+
+[Documentation](#documentation)
+
+pyBOAT features a modular, multi-layered graphical user interface. The example screenshot displays the `DataViewer`(left) used for signal inspection and preprocessing, paired with the resulting `Wavelet Spectrum`, which shows a ridge tracking the main oscillatory component with a  $\sim$ 24h period (right):
 
 <img src="./doc/assets/DataViewerSpectrum.png" alt="DataViewerSpectrum" width="900"/>
 
@@ -39,12 +43,13 @@ source venv-pyboat/bin/activate
 pip install pyboat
 ```
 
-**Windows and MacOS**:
+**MacOS**:
 
-Download the standalone installers from the [release page](https://github.com/tensionhead/pyBOAT/releases).
+Download the latest `pyBOAT-1.x.x.dmg` file from the [release page](https://github.com/tensionhead/pyBOAT/releases/latest), right-click (or Control-click) the installer and select 'Open' to bypass the macOS *untrusted developer* warning. 
 
-* **macOS:** Download the `pyBOAT-1.1.0.dmg` file, and double click to install
-* **Windows:** Download the `pyBOAT-1.1.0.msi` file and run the setup wizard to install.
+**Windows** 
+
+Download the latest `pyBOAT-1.x.x.msi` file from the [release page](https://github.com/tensionhead/pyBOAT/releases/latest) and run the setup wizard to install.
 
 **Via Anaconda Navigator** (legacy)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install pyboat
 
 **MacOS**:
 
-Download the latest `pyBOAT-1.x.x.dmg` file from the [release page](https://github.com/tensionhead/pyBOAT/releases/latest), right-click (or Control-click) the installer and select 'Open' to bypass the macOS *untrusted developer* warning. 
+Download the latest `pyBOAT-1.x.x.dmg` file from the [release page](https://github.com/tensionhead/pyBOAT/releases/latest). To install and launch, you will need to bypass the macOS *untrusted developer* warning twice by right-clicking and selecting 'Open': first on the downloaded `.dmg` installer file, and then a second time on the installed pyBOAT app icon inside Finder.
 
 **Windows** 
 

--- a/pyboat/__init__.py
+++ b/pyboat/__init__.py
@@ -5,7 +5,7 @@ import os
 import argparse
 import logging
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # the object oriented API
 from .api import WAnalyzer

--- a/pyboat/plotting.py
+++ b/pyboat/plotting.py
@@ -265,6 +265,8 @@ def mk_signal_modulus_ax(time_unit="a.u.", height_ratios=[1, 2.5], fig=None):
     if fig is None:
         fig = ppl.figure(figsize=(x_size, 6.5))
         fig.subplots_adjust(bottom=0.07, top=0.97)
+
+    fig.set_layout_engine("tight")
     # 1st axis is for signal, 2nd axis is the spectrum
     axs = fig.subplots(2, 1, gridspec_kw={"height_ratios": height_ratios}, sharex=True)
 

--- a/pyboat/ui/analysis_parameters.py
+++ b/pyboat/ui/analysis_parameters.py
@@ -68,7 +68,7 @@ class SettingsManager(QObject):
         if self._restored == True:
             logger.debug("Restored parameters in %s", self.__class__.__name__)
 
-    def _save_parameters(self):
+    def _store_settings(self):
         settings = QSettings()
         settings.beginGroup("user-settings")
 
@@ -84,7 +84,7 @@ class SettingsManager(QObject):
 
     def eventFilter(self, _source, event) -> bool:
         if event.type() == QEvent.Type.Close:
-            self._save_parameters()
+            self._store_settings()
         # close event needs to be digested further!
         return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
 [tool.briefcase]
 project_name = "pyBOAT"
 bundle = "io.github.tensionhead"
-version = "1.1.0" # Briefcase reads the static fallback string
+version = "1.1.1" # Briefcase reads the static fallback string
 url = "https://github.com/tensionhead/pyBOAT"
 license = "GPL-3.0-or-later"
 author = "tensionhead"


### PR DESCRIPTION
The wonderful interactive plots shrank considerably since 1.1.0 when
replotting :/ This means swapping the deprecated `set_tight_layout` for
`set_layout_engine` changed some rendering mechanics.